### PR TITLE
fix: filter macOS junk entries from zip upload validation

### DIFF
--- a/app/api/submit-zip/route.ts
+++ b/app/api/submit-zip/route.ts
@@ -58,6 +58,23 @@ const BLOCKED_EXTENSIONS = new Set([
 const MAX_SINGLE_FILE_SIZE = 5 * 1024 * 1024;
 
 /**
+ * Returns true for zip entries that are OS-generated junk and should be
+ * ignored during plugin discovery, validation, and repo push.
+ *
+ * Covers:
+ *  - macOS resource-fork metadata (`__MACOSX/` directory tree)
+ *  - macOS Finder metadata (`.DS_Store`)
+ *  - Windows thumbnail cache (`Thumbs.db`)
+ */
+function isJunkEntry(entryPath: string): boolean {
+  const normalized = entryPath.replace(/\\/g, "/");
+  if (normalized.startsWith("__MACOSX/") || normalized === "__MACOSX") return true;
+  const basename = normalized.split("/").pop() || "";
+  if (basename === ".DS_Store" || basename === "Thumbs.db") return true;
+  return false;
+}
+
+/**
  * POST /api/submit-zip
  *
  * Accepts a multipart form with:
@@ -240,6 +257,7 @@ export async function POST(request: NextRequest) {
 
     for (const [filePath, zipEntry] of Object.entries(zip.files)) {
       if (zipEntry.dir) continue; // skip directories
+      if (isJunkEntry(filePath)) continue; // skip OS-generated junk
 
       // Strip the prefix folder if plugin.json was nested
       let repoPath = filePath;
@@ -556,7 +574,7 @@ async function validatePlugin(
   }
 
   // ─── 5. File-level security checks ────────────────────
-  const allPaths = Object.keys(zip.files);
+  const allPaths = Object.keys(zip.files).filter((p) => !isJunkEntry(p));
 
   for (const filePath of allPaths) {
     // Path traversal
@@ -668,6 +686,7 @@ function findPluginJson(zip: JSZip): {
   const topDirs = new Set<string>();
 
   for (const entry of entries) {
+    if (isJunkEntry(entry)) continue;
     const parts = entry.split("/");
     if (parts.length >= 2 && parts[0]) {
       topDirs.add(parts[0]);


### PR DESCRIPTION
### **User description**
## Summary

- Zip files created on macOS include a `__MACOSX/` metadata directory alongside the actual plugin folder. This causes `findPluginJson()` to count two top-level directories instead of one, failing the nested plugin detection and rejecting valid uploads with *"No plugin.json found"*
- Adds `isJunkEntry()` helper that filters `__MACOSX/`, `.DS_Store`, and `Thumbs.db` entries across all three zip processing stages (discovery, validation, and repo push)
- Without this fix, any plugin zip created via macOS Finder's "Compress" produces a false rejection

## Root Cause

```
my-plugin/           ← actual plugin
  plugin.json
  api/
  webui/
__MACOSX/            ← macOS resource fork metadata (invisible in Finder)
  my-plugin/
    ._plugin.json
```

`findPluginJson()` line 678: `topDirs.size === 1` fails because `topDirs` = `{my-plugin, __MACOSX}`.

## Changes

| Location | Change |
|----------|--------|
| `isJunkEntry()` (new) | Helper to identify OS-generated junk entries |
| `findPluginJson()` | Filter junk from top-level directory discovery |
| `validatePlugin()` | Exclude junk from file-level security checks |
| Git push loop | Skip junk when pushing files to created repo |

## Test plan

- [ ] Upload a zip created on macOS via Finder → Compress (previously failed, should now succeed)
- [ ] Upload a zip created via `zip -r` on macOS (may or may not include `__MACOSX` depending on flags)
- [ ] Upload a zip with `plugin.json` at actual root (no wrapping folder) — should still work
- [ ] Upload a zip with `plugin.json` inside a single top-level folder (no `__MACOSX`) — should still work
- [ ] Verify the created GitHub repo does not contain `__MACOSX/` or `.DS_Store` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Bug fix


___

### **Description**
- Filters macOS junk entries (`__MACOSX/`, `.DS_Store`) and Windows metadata (`Thumbs.db`) from zip processing

- Fixes false rejection of valid plugins when compressed via macOS Finder

- Applies filtering across all three zip processing stages: discovery, validation, and repo push

- Prevents junk files from being pushed to created GitHub repositories


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Zip Upload"] --> B["isJunkEntry Helper"]
  B --> C["findPluginJson Discovery"]
  B --> D["validatePlugin Validation"]
  B --> E["Git Push Loop"]
  C --> F["Correct Plugin Detection"]
  D --> G["Security Checks"]
  E --> H["Clean Repository"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>route.ts</strong><dd><code>Add junk entry filtering across zip processing stages</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

app/api/submit-zip/route.ts

<ul><li>Added <code>isJunkEntry()</code> helper function to identify OS-generated junk <br>entries (<code>__MACOSX/</code>, <code>.DS_Store</code>, <code>Thumbs.db</code>)<br> <li> Integrated junk filtering in <code>findPluginJson()</code> to prevent false <br>rejection due to <code>__MACOSX/</code> directory<br> <li> Applied filtering in <code>validatePlugin()</code> to exclude junk files from <br>security checks<br> <li> Added junk filtering in Git push loop to prevent junk files from being <br>committed to repository</ul>


</details>


  </td>
  <td><a href="https://github.com/TerminallyLazy/a0-marketplace-web/pull/2/files#diff-7fec526509443922e6298616a168c484d1f56f8f314589c1f0250ceb0b27bafd">+20/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * ZIP submissions now automatically filter out OS-generated files (such as system metadata) to prevent processing errors and improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->